### PR TITLE
Create 20 by endgame

### DIFF
--- a/20 by endgame
+++ b/20 by endgame
@@ -1,0 +1,39 @@
+key "Level2","300"
+
+key "Level3","400"
+
+key "Level4","540"
+
+key "Level5","730"
+
+key "Level6","980"
+
+key "Level7","1300"
+
+key "Level8","1700"
+
+key "Level9","2190"
+
+key "Level10","2780"
+
+key "Level11","3480"
+
+key "Level12","4300"
+
+key "Level13","5250"
+
+key "Level14","6340"
+
+key "Level15","7580"
+
+key "Level16","8980"
+
+key "Level17","10550"
+
+key "Level18","12300"
+
+key "Level19","14240"
+
+key "Level20","16380"
+
+key "MaxXPLevel","20"


### PR DESCRIPTION
XP curve that gets folks to level 20 by the endgame at roughly the same point where they'd get to level 12 in vanilla (100,000 XP).